### PR TITLE
Limit retries

### DIFF
--- a/server/hump_server.rb
+++ b/server/hump_server.rb
@@ -145,6 +145,7 @@ class HumpServer < Sinatra::Base
       if retried
         raise
       else
+        retried = true
         settings.conn.reset_connection
         retry
       end


### PR DESCRIPTION
Oops, forgot to set `retried = true` when retrying. If there was any kind of error, humps would continually reconnect until eventually unicorn killed the process for being unresponsive.