### PR TITLE
add cors headers

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -7,3 +7,5 @@ gem 'unicorn', '6.1.0'
 gem 'sinatra', '3.0.6'
 gem 'pg', '1.5.3'
 gem 'maxmind-geoip2', '1.1.0'
+
+gem 'sinatra-cors', '~> 1.2'

--- a/server/hump_server.rb
+++ b/server/hump_server.rb
@@ -1,10 +1,15 @@
 class HumpServer < Sinatra::Base
   GEOIP_DB_PATH = '/var/gisdata/geoip/GeoIP2-City.mmdb'
 
+
   configure do
     db_settings = YAML.load(File.read('config/pg.yml'))
     dbs = db_settings[settings.environment.to_s]
     set :conn, DbConnector.new(dbs)
+
+    register Sinatra::Cors
+    set :allow_origin, "*"
+    set :allow_methods, "GET, HEAD, POST"
 
     if File.exist?(GEOIP_DB_PATH)
       set :geoipdb, MaxMind::GeoIP2::Reader.new(GEOIP_DB_PATH)


### PR DESCRIPTION
These CORS headers are acceptable because:

 - This server doesn't have authentication
 - The CORS configuration doesn't allow authentication
 - We're accepting the risk of third party sites making requests against these APIs from their users' browsers

I tested this locally with `/`; can't test with `/get_eles` because I don't have any DEMs