### PR TITLE
fix crash with malformed params

### DIFF
--- a/server/hump_server.rb
+++ b/server/hump_server.rb
@@ -134,8 +134,8 @@ class HumpServer < Sinatra::Base
 
   def get_eles
     callback = params.delete('callback')
-    lats = params[:lats].split(',').collect { |n| n.to_f }
-    lngs = params[:lngs].split(',').collect { |n| n.to_f }
+    lats = params[:lats]&.split(',')&.collect { |n| n.to_f } || []
+    lngs = params[:lngs]&.split(',')&.collect { |n| n.to_f } || []
     eles = []
 
     #this is a super shitty way to do it; i should make a new method


### PR DESCRIPTION
fixes https://github.com/ridewithgps/ridewithgps/issues/15605

now we return an empty array if the params are missing or blank

```
09:37 $ curl http://localhost:4002/get_eles
[]✔ ~/rwgps/humps [master|✚ 1…1⚑ 2] 
09:41 $ curl http://localhost:4002/get_eles
[]✔ ~/rwgps/humps [master|✚ 1…1⚑ 2] 
09:41 $ curl 'http://localhost:4002/get_eles?lats=&lngs='
[]✔ ~/rwgps/humps [master|✚ 1…1⚑ 2] 
09:41 $ curl 'http://localhost:4002/get_eles?lats=34&lngs='
[]✔ ~/rwgps/humps [master|✚ 1…1⚑ 2] 
09:41 $ curl 'http://localhost:4002/get_eles?lats=34&lngs=32'
[-9999]✔ ~/rwgps/humps [master|✚ 1…1⚑ 2] 
09:41 $ curl 'http://localhost:4002/get_eles?lats=34&lngs=32,34'
[-9999,-9999]✔ ~/rwgps/humps [master|✚ 1…1⚑ 2] 
09:41 $ curl 'http://localhost:4002/get_eles?lats=34&lngs=32,34,32342'
[-9999,-9999,-9999]✔ ~/rwgps/humps [master|✚ 1…1⚑ 2] 
```