### PR TITLE
Development environment with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# Dockerfile
-
 FROM ruby:2.7.6
 
 ENV ROOTDIR=/var/www/humps/current
@@ -8,7 +6,7 @@ COPY . $ROOTDIR
 WORKDIR $WORKDIR
 RUN gem install bundler:2.4.17
 RUN cd $WORKDIR;bundle install
-RUN mkdir -p $WORKDIR/tmp/pids $WORKDIR/log
+RUN mkdir -p /tmp/pids $WORKDIR/log
 
 VOLUME /var/gisdata
 EXPOSE 4002

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,24 @@
+FROM ruby:2.7.6
+
+ENV ROOTDIR=/var/www/humps/current
+ENV WORKDIR=$ROOTDIR/server
+
+WORKDIR $ROOTDIR
+RUN mkdir -p $ROOTDIR/lib
+COPY ./lib $ROOTDIR/lib/
+
+WORKDIR $WORKDIR
+RUN mkdir -p /tmp/pids $WORKDIR/log
+COPY server/Gemfile .
+COPY server/Gemfile.lock .
+
+RUN gem install bundler:2.4.17
+RUN cd $WORKDIR;bundle install
+
+VOLUME /var/gisdata
+EXPOSE 4002
+
+ENTRYPOINT bundle exec unicorn -c $WORKDIR/config/unicorn.rb -E development $WORKDIR/config-development.ru
+
+
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Humps expects your DEMs to be GridFloat, which is a simple binary grid of elevat
 
 This library is in use at [ridewithgps](http://ridewithgps.com) and is tailored towards our elevation datasets.  Meaning, there are a bunch of hardcoded things in here that may or may not apply to your elevation dataset. For example, we just updated our SRTM dataset and the number of rows/columns in each tile changed, necessitating the change of some hardcoded values used to lookup header files.  At some point that stuff will all be extracted out or made generic, but that day is not today.
 
+# Run locally with Docker
+
+```bash
+docker build --no-cache -t humps -f Dockerfile.development .
+docker run -it --rm --name humps -v ./server:/var/www/humps/current/server -p 127.0.0.1:4002:4002 humps
+```
+
 ## GeoIP
 
 Humps also does GeoIP queries using MaxMind's GeoIP2 City database [found here](https://www.maxmind.com/en/geoip2-city). The database is a binary file and needs to be manually added here: `server/db/geo-ip.mmdb`.

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -8,4 +8,6 @@ gem 'sinatra', '3.0.6'
 gem 'pg', '1.5.3'
 gem 'maxmind-geoip2', '1.1.0'
 
+gem 'rack-unreloader'
+
 gem 'sinatra-cors', '~> 1.2'

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -1,29 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.4)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
     connection_pool (2.4.1)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
-    ffi (1.15.5)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
+    domain_name (0.6.20240107)
+    ffi (1.17.0)
+    ffi-compiler (1.3.2)
+      ffi (>= 1.15.5)
       rake
-    http (5.1.1)
+    http (5.2.0)
       addressable (~> 2.8)
+      base64 (~> 0.1)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.4.0)
-    http-cookie (1.0.5)
+      llhttp-ffi (~> 0.5.0)
+    http-cookie (1.0.6)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     json (2.6.3)
     kgio (2.11.4)
-    llhttp-ffi (0.4.0)
+    llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    maxmind-db (1.1.1)
+    maxmind-db (1.2.0)
     maxmind-geoip2 (1.1.0)
       connection_pool (~> 2.2)
       http (>= 4.3, < 6.0)
@@ -31,22 +32,21 @@ GEM
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     pg (1.5.3)
-    public_suffix (5.0.3)
+    public_suffix (5.1.1)
     rack (2.2.8)
     rack-protection (3.0.6)
       rack
+    rack-unreloader (2.1.0)
     raindrops (0.20.1)
-    rake (13.0.6)
+    rake (13.2.1)
     ruby2_keywords (0.0.5)
     sinatra (3.0.6)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
       rack-protection (= 3.0.6)
       tilt (~> 2.0)
+    sinatra-cors (1.2.0)
     tilt (2.2.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -54,14 +54,17 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
-  json
+  json (= 2.6.3)
   maxmind-geoip2 (= 1.1.0)
   pg (= 1.5.3)
+  rack-unreloader
   sinatra (= 3.0.6)
+  sinatra-cors (~> 1.2)
   unicorn (= 6.1.0)
-  yajl-ruby
+  yajl-ruby (= 1.4.3)
 
 BUNDLED WITH
    2.4.17

--- a/server/config-development.ru
+++ b/server/config-development.ru
@@ -1,9 +1,11 @@
+require 'rack/unreloader'
 require 'rubygems'
 require 'bundler'
 require 'yaml'
 Bundler.require
 require '../lib/humps'
 require File.join(File.dirname(__FILE__), 'db', 'db_connector.rb')
-require File.join(File.dirname(__FILE__), 'hump_server.rb')
 
-run HumpServer
+Unreloader = Rack::Unreloader.new { HumpServer }
+Unreloader.require './hump_server.rb'
+run Unreloader

--- a/server/config/unicorn.rb
+++ b/server/config/unicorn.rb
@@ -6,9 +6,9 @@ preload_app true
 timeout 40
 
 # Listen on a Unix data socket
-listen '0.0.0.0:4002', :tcp_nopush => true, :backlog => 1024
+listen '0.0.0.0:4002', tcp_nopush: true, backlog: 1024
 
-pid "/var/www/humps/current/server/tmp/pids/unicorn.pid"
+pid "/tmp/pids/unicorn.pid"
 
 before_fork do |server, worker|
   # This allows a new master process to incrementally

--- a/server/hump_server.rb
+++ b/server/hump_server.rb
@@ -1,7 +1,6 @@
 class HumpServer < Sinatra::Base
   GEOIP_DB_PATH = '/var/gisdata/geoip/GeoIP2-City.mmdb'
 
-
   configure do
     db_settings = YAML.load(File.read('config/pg.yml'))
     dbs = db_settings[settings.environment.to_s]

--- a/server/stop_server.sh
+++ b/server/stop_server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pidfile="/var/www/humps/current/server/tmp/pids/unicorn.pid"
+pidfile="/tmp/pids/unicorn.pid"
 
 if [[ -f $pidfile ]]; then
     kill `cat $pidfile`


### PR DESCRIPTION
This is to facilitate development of the Sinatra app by providing a development environment where files are reloaded with `rack-unreloader` as they change.

Only change for the production environment is the move of the `pids/` directory from `/var/www/humps/current/server/tmp/` to the `/tmp` directory of the container.